### PR TITLE
Change assumed shape of time series to timepoints*channels

### DIFF
--- a/sktime_neuro/examples/Motor_Imagery_Example.ipynb
+++ b/sktime_neuro/examples/Motor_Imagery_Example.ipynb
@@ -50,7 +50,9 @@
     ")\n",
     "\n",
     "raw = read_raw_bids(bids_path=bids_path, verbose=False)\n",
-    "data = raw.get_data()"
+    "\n",
+    "# mne assumes shape channels*timepoints;sktime assumes shape timepoints*channels\n",
+    "data = raw.get_data().transpose()"
    ]
   },
   {
@@ -78,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "detrended_data = Detrender().fit_transform(pd.DataFrame(downsampled_data.transpose()))"
+    "detrended_data = Detrender().fit_transform(pd.DataFrame(downsampled_data))"
    ]
   },
   {
@@ -89,7 +91,7 @@
    "outputs": [],
    "source": [
     "filtered_data = FilterforSeries(l_freq=8, h_freq=16, sfreq=250).fit_transform(\n",
-    "    detrended_data.transpose()\n",
+    "    detrended_data\n",
     ")"
    ]
   },

--- a/sktime_neuro/tests/test_filterforseries.py
+++ b/sktime_neuro/tests/test_filterforseries.py
@@ -64,13 +64,14 @@ def test_filter_kwargs(kwargs):
 @pytest.mark.parametrize("hfreq", [11, 20, None])
 def test_filter_results(sfreq, lfreq, hfreq):
     np.random.seed(42)
-    X = 0.02 * np.random.randn(30, 1000)
+    X = 0.02 * np.random.randn(1000, 30)
 
-    # sklearn
+    # sktime
     Filter = FilterforSeries(sfreq=sfreq, l_freq=lfreq, h_freq=hfreq)
     Xt1 = Filter.fit_transform(X)
 
     # mne
-    Xt2 = filter.filter_data(X, sfreq=sfreq, l_freq=lfreq, h_freq=hfreq)
+    X = X.transpose()
+    Xt2 = filter.filter_data(X, sfreq=sfreq, l_freq=lfreq, h_freq=hfreq).transpose()
 
     assert np.allclose(Xt1, Xt2)

--- a/sktime_neuro/transformations/series/filterforseries.py
+++ b/sktime_neuro/transformations/series/filterforseries.py
@@ -65,7 +65,8 @@ class FilterforSeries(_SeriesToSeriesTransformer):
         Parameters
         ----------
         Z : 2D numpy array, pd.Series or pd.DataFrame
-        (will get coerced to numpy)
+        (will get coerced to numpy); needs to be of
+        shape timepoints*channels
 
         Returns
         -------
@@ -79,8 +80,14 @@ class FilterforSeries(_SeriesToSeriesTransformer):
         if isinstance(z, (pd.DataFrame, pd.Series)):
             z = z.to_numpy()
 
+        # mne needs timepoints to be the last dimension
+        z = z.transpose()
+
+        # z is now of shape channels * timepoints
         z = filter.filter_data(
             z, sfreq=self.sfreq, l_freq=self.l_freq, h_freq=self.h_freq, **self.kwargs
         )
 
+        # transpose back to have sktime shape again (timepoints*channels)
+        z = z.transpose()
         return z

--- a/sktime_neuro/transformations/series/seriesdownsampling.py
+++ b/sktime_neuro/transformations/series/seriesdownsampling.py
@@ -5,6 +5,7 @@ __all__ = ["SeriesDownsampling"]
 from sktime_neuro.transformations.base import _SeriesToSeriesTransformer
 from sktime.utils.validation.series import check_series
 import numpy as np
+import pandas as pd
 
 
 class SeriesDownsampling(_SeriesToSeriesTransformer):
@@ -37,7 +38,8 @@ class SeriesDownsampling(_SeriesToSeriesTransformer):
         Parameters
         _________
         X : np.array
-            shape: channels*timepoints
+            shape: timepoints*channels
+            (also accepts pd.DataFrame that will get coerced to numpy)
 
         Returns
         ________
@@ -51,7 +53,11 @@ class SeriesDownsampling(_SeriesToSeriesTransformer):
         if self.factor > Z.shape[1]:
             raise ValueError("Factor too high for shape of Series.")
 
-        z = z[:, 0 :: self.factor]
+        # deals with numpy arrays:
+        if isinstance(z, (pd.DataFrame, pd.Series)):
+            z = z.to_numpy()
+
+        z = z[0 :: self.factor, :]
         # do we need a warning about this?
         # print("The new sampling frequency is:" + str(self.fs / self.factor))
         return z

--- a/sktime_neuro/transformations/series_to_panel/eeg_epoching.py
+++ b/sktime_neuro/transformations/series_to_panel/eeg_epoching.py
@@ -9,6 +9,9 @@ def epoch(Z, annotation, labels, interval, sfreq) -> (np.array, np.array):
     """
     Parameters
     _________
+    Z : np.array
+        time series to be epoched
+        shape: timepoints*channels
     annotation : pd.DataFrame,
         one row per event with columns "onset", "duration"
         and "descritption"
@@ -32,7 +35,7 @@ def epoch(Z, annotation, labels, interval, sfreq) -> (np.array, np.array):
     Z = check_series(Z)
 
     # create shape of final data
-    n_channels = Z.shape[0]
+    n_channels = Z.shape[1]
     n_timepoints = int(interval[1] * sfreq) - int(interval[0] * sfreq)
     n_trials = len(annotation.loc[lambda df: df["description"].isin(labels)]["onset"])
     X = np.zeros((n_trials, n_channels, n_timepoints))
@@ -48,12 +51,14 @@ def epoch(Z, annotation, labels, interval, sfreq) -> (np.array, np.array):
         # iterate over onsets and add them to the datacontainer (X) and labels (y)
         for onset in onsets_of_label:
             offset = int(sfreq * onset)
-            X[idx] = Z[
-                :,
-                (int(interval[0] * sfreq) + offset) : (
-                    int(interval[1] * sfreq) + offset
-                ),
-            ]
+            X[idx] = (
+                Z[
+                    (int(interval[0] * sfreq) + offset) : (
+                        int(interval[1] * sfreq) + offset
+                    ),
+                    :,
+                ]
+            ).transpose()
             y.append(label)
             idx += 1
     return X, np.asarray(y)


### PR DESCRIPTION
I assumed the shape of sktime time series to be `channels * timepoints` (as it is for example defined in mne). But when reviewing the specifications made in PR #1232 in sktime, I figured that it is supposed to be `timepoints * channels`. 

This required changes in

- the two series-to-series transformers
- the epoching function and 
- the example notebook. 